### PR TITLE
Support for install/reinstall after an update via git pull

### DIFF
--- a/install.py
+++ b/install.py
@@ -48,5 +48,13 @@ if __name__ == '__main__':
     with open(cwd + "/apktool.jar", 'wb') as f:
         f.write(data)
     parent = os.path.dirname(cwd)
-    os.system("cd "+cwd+" && git clone https://github.com/androguard/androguard.git && cd "+cwd+"/androguard && python3 setup.py install")
-    os.system("cd "+cwd+" && git clone https://github.com/neskk/xmind-sdk-python3.git && cd "+cwd+"/xmind-sdk-python3 && python3 setup.py install")
+
+    if not os.path.exists(cwd+"/androguard"):
+        os.system("cd "+cwd+" && git clone https://github.com/androguard/androguard.git && cd "+cwd+"/androguard && python3 setup.py install")
+    else:
+        os.system("cd "+cwd+"/androguard && git pull && python3 setup.py install")
+
+    if not os.path.exists(cwd+"/xmind-sdk-python3"):
+        os.system("cd "+cwd+" && git clone https://github.com/neskk/xmind-sdk-python3.git && cd "+cwd+"/xmind-sdk-python3 && python3 setup.py install")
+    else:
+        os.system("cd "+cwd+"/xmind-sdk-python3 && git pull && python3 setup.py install")


### PR DESCRIPTION
This is what happens when you perform a reinstall or update after a git pull:
```bash
root@kali:~/droidstatx# git pull
Already up to date.
root@kali:~/droidstatx# python3 install.py
[-]Downloading latest Apktool version...
Downloaded 16314178 of 16314178 bytes (100.00%)
fatal: destination path 'androguard' already exists and is not an empty directory.
fatal: destination path 'xmind-sdk-python3' already exists and is not an empty directory.
```