### PR TITLE
Fix TypeError: '<=' not supported between instances of 'str' and 'int'

### DIFF
--- a/App.py
+++ b/App.py
@@ -351,7 +351,7 @@ class App:
                 self.smaliChecks.determineContentProviderSQLi(providerName)
                 self.smaliChecks.determineContentProviderPathTraversal(providerName)
             elif provider.get(self.NS_ANDROID + "exported") != 'false':
-                if self.minSDKVersion <= 16:
+                if int(self.minSDKVersion) <= 16:
                     self.extractComponentPermission(provider)
                     self.smaliChecks.determineContentProviderSQLi(providerName)
                     self.smaliChecks.determineContentProviderPathTraversal(providerName)


### PR DESCRIPTION
Env:
--------------------------
Python 3.7.4 (pyenv)
Mac OSX 10.14.6

Log:
--------------------------
[-] Parsing APK
[-] Baksmaling DEX files
[+] Gathering Information
   [-] Package Properties
   [-] Exported Components
Traceback (most recent call last):
  File "droidstatx.py", line 31, in <module>
    a = App(args.apk[0])
  File "/Users/me/Documents/Android/droidstatx/App.py", line 106, in __init__
    self.extractExportedComponents()
  File "/Users/me/Documents/Android/droidstatx/App.py", line 382, in extractExportedComponents
    self.extractExportedProviders()
  File "/Users/me/Documents/Android/droidstatx/App.py", line 354, in extractExportedProviders
    if self.minSDKVersion <= 16:
TypeError: '<=' not supported between instances of 'str' and 'int'